### PR TITLE
Add Jest tests for toggleScrollTop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# partydisturbance
+# Party Disturbance
+
+## Rodando os testes
+
+Instale as dependências e execute o Jest:
+
+```bash
+npm install
+npm test
+```

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -91,6 +91,10 @@
   window.addEventListener('load', toggleScrollTop);
   document.addEventListener('scroll', toggleScrollTop);
 
+  if (typeof module !== 'undefined') {
+    module.exports.toggleScrollTop = toggleScrollTop;
+  }
+
   /**
    * Animation on scroll function and init
    */
@@ -126,9 +130,9 @@
   /**
    * Initiate glightbox
    */
-  const glightbox = GLightbox({
+  const glightbox = typeof GLightbox !== 'undefined' ? GLightbox({
     selector: '.glightbox'
-  });
+  }) : null;
 
   /**
    * Init isotope layout and filters
@@ -166,7 +170,9 @@
   /**
    * Initiate Pure Counter
    */
-  new PureCounter();
+  if (typeof PureCounter !== 'undefined') {
+    new PureCounter();
+  }
 
   /**
    * Correct scrolling position upon page load for URLs containing hash links.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "partydisturbance",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/toggleScrollTop.test.js
+++ b/tests/toggleScrollTop.test.js
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+
+global.GLightbox = function() { return {}; };
+global.PureCounter = function() {};
+
+const { toggleScrollTop } = require('../assets/js/main.js');
+
+describe('toggleScrollTop', () => {
+  let button;
+  beforeEach(() => {
+    document.body.innerHTML = '<div class="scroll-top"></div>';
+    button = document.querySelector('.scroll-top');
+  });
+
+  test('adds active when scrollY > 100', () => {
+    Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: 150 });
+    toggleScrollTop();
+    expect(button.classList.contains('active')).toBe(true);
+  });
+
+  test('removes active when scrollY <= 100', () => {
+    button.classList.add('active');
+    Object.defineProperty(window, 'scrollY', { writable: true, configurable: true, value: 50 });
+    toggleScrollTop();
+    expect(button.classList.contains('active')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- export `toggleScrollTop` in `assets/js/main.js` and guard against missing dependencies
- create Jest test to validate the behaviour of `toggleScrollTop`
- add package.json with Jest
- update README with instructions on running tests

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9f634e6083289360880b523ef39b